### PR TITLE
Use Typekit webfont and override stylesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ Inspired by https://github.com/allenwhale/react-redux-boilerplate
 
 ### Contribution
 ---
- - for latest release please checkout master branch
- - for contributing developpemnt please checkout dev branch 
+ - For latest release please checkout master branch
+ - For contributing developpemnt please checkout dev branch 
+
+# Important
+ - After cloning or forking the repo, go to ```src/js/utils``` and change the ```confing.js.sample``` file into ```config.js``` to prevent critical building error.
 
 ### Issue tracking
 ---
@@ -38,6 +41,7 @@ Inspired by https://github.com/allenwhale/react-redux-boilerplate
  - Go to "Board" and pick a newbies issue
  - Fork repo
  - Pull from dev branch
+ - Fix the config problem mentioned above
  - Make your changes(solve the issue)
  - Send pull request
  
@@ -56,6 +60,3 @@ Inspired by https://github.com/allenwhale/react-redux-boilerplate
  - fb group: https://www.facebook.com/groups/internlens
  - email: internlens.tw@gmail.com
  - website: https://internlens.com/
-
-
-

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -30,6 +30,8 @@
         <link rel="apple-touch-icon" href="./img/favicon-128x128.png">
         <link rel="icon" href="favicon.ico" type="image/x-icon" />
         <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
+        <script src="https://use.typekit.net/kxi8dqi.js"></script>
+        <script>try{Typekit.load({ async: true });}catch(e){}</script>
         <script src='https://www.google.com/recaptcha/api.js'></script>
     </head>
 

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -7,3 +7,26 @@
 .grommetux-heading--strong {
     font-family: "source-han-serif-tc",serif;
 }
+
+h1.grommetux-heading{
+    font-weight: 800;
+}
+
+h2.grommetux-heading{
+    font-weight: 600;
+}
+
+
+h3.grommetux-heading--strong {
+    font-size: 26px;
+    font-weight: 700;
+}
+
+h4.grommetux-heading{
+    line-height: 1.7em;
+}
+
+h4.grommetux-heading--strong {
+    font-size: 22px;
+    font-weight: 700;
+}

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -3,3 +3,7 @@
 .grommet, .brand-font {
     font-family: "source-han-sans-traditional", Arial, sans-serif;
 }
+
+.grommetux-heading--strong {
+    font-family: "source-han-serif-tc",serif;
+}

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -1,1 +1,5 @@
 @import '~grommet/scss/hpinc/index';
+
+.grommet, .brand-font {
+    font-family: "source-han-sans-traditional", Arial, sans-serif;
+}


### PR DESCRIPTION
In order to use source han sans and serif font and uniformize our user experience.